### PR TITLE
Configure GitHub Actions to run the build

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,5 @@ quote_type = single
 max_line_length = off
 trim_trailing_whitespace = false
 
-[*.json]
+[*.{json,yml,yaml}]
 indent_size = 2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,36 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "**"
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version:
+          - 18
+          - 20
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.JS ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      # - name: Run tests
+      #   run: npm run test


### PR DESCRIPTION
This PR is adding a GitHub Action that will do the following on each push and each tag:
- it will checkout the content of the repository
- it will install the NPM dependencies (from the lock file)
- it will try to perform a build, using `npm run build`
- and when in the future some real and working tests are added to the project, we can uncomment the last part, which will be the way to run them

It will run the following for the two last Node.JS versions, which are 18 and 20 for now.

The goal of this GitHub Action is to:
- check that there are no issue when installing dependencies
- check that everything is able to build as expected ; if not, it will let you know the issues by checking the log of the job
- in the future: run tests, to make sure everything is running as expected

I also configured the `indent_size` for YAML files to 2.

Right now, jobs are failing because of an issue with the lock file.
Once #9 would be merged, this should be working as expected for the `main` branch.