### PR TITLE
[CI] Use Node.JS LTS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,20 +11,14 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version:
-          - 18
-          - 20
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Node.JS ${{ matrix.node-version }}
+      - name: Set up Node.JS
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: "lts/*"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This PR updates the Node.JS version used in GitHub Actions, so that it targets the current LTS version.

This is a first step for fixing the build issues reported on GitHub Actions.
There are some things to update (in a follow-up PR) in order to fix module resolution and some types.